### PR TITLE
Changed values of log levels

### DIFF
--- a/lib/wolverine.js
+++ b/lib/wolverine.js
@@ -32,12 +32,12 @@ var Wolverine = function Wolverine(level, options) {
  * Create the log levels
  */
 Wolverine.ALL = -Infinity;
-Wolverine.VERBOSE = 0;
-Wolverine.DEBUG = 1;
-Wolverine.INFO =  2;
-Wolverine.WARN =  3;
-Wolverine.ERROR = 4;
-Wolverine.FATAL = 5;
+Wolverine.VERBOSE = 10;
+Wolverine.DEBUG = 20;
+Wolverine.INFO =  30;
+Wolverine.WARN =  40;
+Wolverine.ERROR = 50;
+Wolverine.FATAL = 60;
 Wolverine.OFF = Infinity;
 
 var getDate = function getDate() {

--- a/test/wolverineTest.js
+++ b/test/wolverineTest.js
@@ -25,6 +25,11 @@ describe('Common tests', function() {
     expect(defaultLog.info('Message')).to.equal('[INFO]\tMessage');
   });
 
+  it('Should log verbose messages if VERBOSE level is set', function () {
+    var verboseLog = new Wolverine(Wolverine.VERBOSE, {time: false, silent: true});
+    expect(verboseLog.verbose('Message')).to.equal('[VERBOSE]\tMessage');
+  });
+
   it('Just the message', function() {
     expect(infoLog.info('Message')).to.equal('[INFO]\tMessage');
   });
@@ -50,7 +55,7 @@ describe('Common tests', function() {
 
   it('Should show the line', function() {
     var lineLog = new Wolverine({time: false, silent: true, printFileInfo: true});
-    expect(lineLog.info('Message')).to.equal('[wolverineTest.js:53]\t[INFO]\tMessage');
+    expect(lineLog.info('Message')).to.equal('[wolverineTest.js:58]\t[INFO]\tMessage');
   });
 
 });


### PR DESCRIPTION
When verbose level was set, log messages with verbose level were not displaying. The reason was that the condition for allowed logging level (https://github.com/talyssonoc/WolverineJS/blob/master/lib/wolverine.js#L76) was false with `wolverineObj.level` set to `0`.

I changed values of log levels to be equal: 10, 20, 30.. This is the common used practice for logging libraries, especially for the case, when you want to add a custom log level with the weight between the existing ones.

I have written the falling test for this issue and this changes makes this test pass.
